### PR TITLE
Use unstable github-runner for node20 support

### DIFF
--- a/agents/linux.nix
+++ b/agents/linux.nix
@@ -1,9 +1,13 @@
 { pkgs, ... }: 
 
-let 
+let
   name = "cachix-${pkgs.stdenv.system}";
 in {
-  imports = [ ../common.nix ];
+  disabledModules = [ "services/continuous-integration/github-runners.nix" ];
+  imports = [
+    ../common.nix
+    "${pkgs.unstable}/nixos/modules/services/continuous-integration/github-runners.nix"
+  ];
 
   nix.settings.trusted-users = [ "root" "github-runner" ];
   nix.extraOptions = "extra-experimental-features = flakes nix-command";
@@ -25,6 +29,7 @@ in {
     url = "https://github.com/cachix";
     user = "github-runner";
     tokenFile = "/etc/secrets/github-runner/cachix.token";
+    nodeRuntimes = [ "node16" "node20" ];
     serviceOverrides = {
       # needed for Cachix installation to work
       ReadWritePaths = [ "/nix/var/nix/profiles/per-user/" ];

--- a/flake.lock
+++ b/flake.lock
@@ -355,6 +355,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1696019113,
+        "narHash": "sha256-X3+DKYWJm93DRSdC5M6K5hLqzSya9BjibtBsuARoPco=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f5892ddac112a1e9b3612c39af1b72987ee5783a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1687977148,
@@ -467,6 +483,7 @@
         "devenv": "devenv",
         "disko": "disko_2",
         "nixpkgs": "nixpkgs_5",
+        "nixpkgs-unstable": "nixpkgs-unstable",
         "srvos": "srvos"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -5,24 +5,30 @@
     cachix-deploy-flake.url = "github:cachix/cachix-deploy-flake";
     devenv.url = "github:cachix/devenv/latest";
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.05";
-    srvos.url = "github:numtide/srvos"; 
+    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
+    srvos.url = "github:numtide/srvos";
     disko.url = "github:nix-community/disko/aeebdc1156c1ef6cb1e8f75c3f53bc34f33fad6f";
   };
 
-  outputs = { self, devenv, nixpkgs, cachix-deploy-flake, srvos, disko, ... }: 
+  outputs = { self, devenv, nixpkgs, nixpkgs-unstable, cachix-deploy-flake, srvos, disko, ... }:
     let
       linuxMachineName = "linux";
       sshPubKey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC7CTy+OMdA1IfR3EEuL/8c9tWZvfzzDH9cYE1Fq8eFsSfcoFKtb/0tAcUrhYmQMJDV54J7cLvltaoA4MV788uKl+rlqy17rKGji4gC94dvtB9eIH11p/WadgGORnjdiIV1Df29Zmjlm5zqNo2sZUxs0Nya2I4Dpa2tdXkw6piVgMtVrqPCM4W5uorX8CE+ecOUzPOi11lyfCwLcdg0OugXBVrNNSfnJ2/4PrLm7rcG4edbonjWa/FvMAHxN7BBU5+aGFC5okKOi5LqKskRkesxKNcIbsXHJ9TOsiqJKPwP0H2um/7evXiMVjn3/951Yz9Sc8jKoxAbeH/PcCmMOQz+8z7cJXm2LI/WIkiDUyAUdTFJj8CrdWOpZNqQ9WGiYQ6FHVOVfrHaIdyS4EOUG+XXY/dag0EBueO51i8KErrL17zagkeCqtI84yNvZ+L2hCSVM7uDi805Wi9DTr0pdWzh9jKNAcF7DqN16inklWUjtdRZn04gJ8N5hx55g2PAvMYWD21QoIruWUT1I7O9xbarQEfd2cC3yP+63AHlimo9Aqmj/9Qx3sRB7ycieQvNZEedLE9xiPOQycJzzZREVSEN1EK1xzle0Hg6I7U9L5LDD8yXkutvvppFb27dzlr5MTUnIy+reEHavyF9RSNXHTo57myffl8zo2lPjcmFkffLZQ== ielectric@kaki";
 
       lib = nixpkgs.lib;
       forAllSystems = lib.genAttrs ["x86_64-linux" "aarch64-darwin" "aarch64-linux"];
-      common = system: rec {
+      config =  {
         # nodejs is needed for github-runner, will be fixed in the next release
-        pkgs = import nixpkgs { 
-          inherit system; 
-          config = {
-            permittedInsecurePackages = [ "nodejs-16.20.2" ];
-          };
+        permittedInsecurePackages = [ "nodejs-16.20.2" ];
+      };
+      common = system: rec {
+        pkgs = import nixpkgs {
+          inherit config system;
+          overlays = [
+            (final: prev: {
+              unstable = import nixpkgs-unstable { inherit config system; };
+            })
+          ];
         };
         cachix-deploy-lib = cachix-deploy-flake.lib pkgs;
         bootstrapNixOS = 


### PR DESCRIPTION
Can be reverted if/when node20 runtime support is backported to stable.