### PR TITLE
Add workflow to auto-bump flake inputs

### DIFF
--- a/.github/workflows/bump-flake-inputs.yml
+++ b/.github/workflows/bump-flake-inputs.yml
@@ -1,0 +1,30 @@
+name: Bump Flake inputs
+
+on:
+  schedule:
+    - cron: '0 6 1,16 * *' # Twice a month (1st and 16th) at 6am.
+
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Bump Flake inputs
+        run: nix flake update --commit-lock-file
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          title: Bump Flake inputs
+          branch: automated/bump-flake-inputs
+          labels: |
+            dependencies
+            automated


### PR DESCRIPTION
1. Bumps flake inputs on a schedule.
2. Opens a PR.
3. The deploy workflow tries to build the configurations.
4. Merge PR if builds pass.
5. The deploy workflow deploys the machines.