### PR TITLE
linux: add github-runner token via sops

### DIFF
--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,0 +1,9 @@
+keys:
+  - &admin_sander age138vqkmsve6sgesskmxefec22h2r0hukhlqlenq3nlgs9tuq3e9yq0xr4le
+  - &server_aarch64_linux age1xs6sg06q2jj93skp6s0advfa666hjxr28c8f5egc2r3fvclwwgzst7uuk0
+creation_rules:
+  - path_regex: secrets\.(yaml|json|env|ini)$
+    key_groups:
+    - age:
+      - *admin_sander
+      - *server_aarch64_linux

--- a/.sops.yaml
+++ b/.sops.yaml
@@ -1,9 +1,11 @@
 keys:
+  - &admin_domen age1pwtvmk9hhwgytkumpjxctvzyw9pledgm44qn8xjzq3s8rduy7fjqllp0nz
   - &admin_sander age138vqkmsve6sgesskmxefec22h2r0hukhlqlenq3nlgs9tuq3e9yq0xr4le
   - &server_aarch64_linux age1xs6sg06q2jj93skp6s0advfa666hjxr28c8f5egc2r3fvclwwgzst7uuk0
 creation_rules:
   - path_regex: secrets\.(yaml|json|env|ini)$
     key_groups:
     - age:
+      - *admin_domen
       - *admin_sander
       - *server_aarch64_linux

--- a/README.md
+++ b/README.md
@@ -1,10 +1,26 @@
-# linux
+# Linux
 
 Based on [cachix-deploy-hetzner-dedicated](https://github.com/cachix/cachix-deploy-hetzner-dedicacted).
 
 
-# macos 
+# MacOS
 
 Based on [Cachix Deploy for nix-darwin](https://docs.cachix.org/deploy/running-an-agent/darwin).
 
 Make sure to install rosetta: `softwareupdate --install-rosetta --agree-to-license`
+
+# Secrets
+
+Secrets are managed by sops: https://github.com/Mic92/sops-nix
+
+Add a new secret:
+
+```shell
+sops secrets.yaml
+```
+
+To add a new key, edit `.sops.yaml`, then run:
+
+```shell
+sops updatekeys secrets.yaml
+```

--- a/agents/linux.nix
+++ b/agents/linux.nix
@@ -34,6 +34,7 @@ in {
     enable = true;
     url = "https://github.com/cachix";
     user = "github-runner";
+    replace = true;
     tokenFile = config.sops.secrets.github-runner-token.path;
     serviceOverrides = {
       # needed for Cachix installation to work

--- a/agents/linux.nix
+++ b/agents/linux.nix
@@ -1,4 +1,4 @@
-{ pkgs, ... }:
+{ config, pkgs, ... }:
 
 let
   name = "cachix-${pkgs.stdenv.system}";
@@ -23,11 +23,18 @@ in {
   # we set home entry in nss to match $HOME
   users.users.github-runner.home = "/run/github-runner/${name}";
 
+  sops.defaultSopsFile = ../secrets.yaml;
+  sops.age.sshKeyPaths = [ "/etc/ssh/ssh_host_ed25519_key" ];
+  sops.age.keyFile = "/var/lib/sops-nix/key.txt";
+  sops.age.generateKey = true;
+
+  sops.secrets.github-runner-token.owner = "github-runner";
+
   services.github-runners.${name} = {
     enable = true;
     url = "https://github.com/cachix";
     user = "github-runner";
-    tokenFile = "/etc/secrets/github-runner/cachix.token";
+    tokenFile = config.sops.secrets.github-runner-token.path;
     serviceOverrides = {
       # needed for Cachix installation to work
       ReadWritePaths = [ "/nix/var/nix/profiles/per-user/" ];

--- a/flake.lock
+++ b/flake.lock
@@ -162,11 +162,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718242063,
-        "narHash": "sha256-n3AWItJ4a94GT0cray/eUV7tt3mulQ52L+lWJN9d1E8=",
+        "lastModified": 1718588625,
+        "narHash": "sha256-8ZbrJq1jcmyzJ4SDkvd8JOZD4/fNUHpL4cpqVe4w3CU=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "832a9f2c81ff3485404bd63952eadc17bf7ccef2",
+        "rev": "8262659fc990cecdf6a8de74c3de7b6ec58c2276",
         "type": "github"
       },
       "original": {
@@ -608,11 +608,11 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1717880976,
-        "narHash": "sha256-BRvSCsKtDUr83NEtbGfHLUOdDK0Cgbezj2PtcHnz+sQ=",
+        "lastModified": 1718478900,
+        "narHash": "sha256-v43N1gZLcGkhg3PdcrKUNIZ1L0FBzB2JqhIYEyKAHEs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4913a7c3d8b8d00cb9476a6bd730ff57777f740c",
+        "rev": "c884223af91820615a6146af1ae1fea25c107005",
         "type": "github"
       },
       "original": {
@@ -666,22 +666,6 @@
       "original": {
         "owner": "NixOS",
         "ref": "nixos-23.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_5": {
-      "locked": {
-        "lastModified": 1717774105,
-        "narHash": "sha256-HV97wqUQv9wvptiHCb3Y0/YH0lJ60uZ8FYfEOIzYEqI=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "d226935fd75012939397c83f6c385e4d6d832288",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -778,15 +762,17 @@
     },
     "sops-nix": {
       "inputs": {
-        "nixpkgs": "nixpkgs_5",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1718137936,
-        "narHash": "sha256-psA+1Q5fPaK6yI3vzlLINNtb6EeXj111zQWnZYyJS9c=",
+        "lastModified": 1718506969,
+        "narHash": "sha256-Pm9I/BMQHbsucdWf6y9G3xBZh3TMlThGo4KBbeoeczg=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "c279dec105dd53df13a5e57525da97905cc0f0d6",
+        "rev": "797ce4c1f45a85df6dd3d9abdc53f2691bea9251",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -606,6 +606,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-stable_3": {
+      "locked": {
+        "lastModified": 1717880976,
+        "narHash": "sha256-BRvSCsKtDUr83NEtbGfHLUOdDK0Cgbezj2PtcHnz+sQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4913a7c3d8b8d00cb9476a6bd730ff57777f740c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "release-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1692808169,
@@ -650,6 +666,22 @@
       "original": {
         "owner": "NixOS",
         "ref": "nixos-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_5": {
+      "locked": {
+        "lastModified": 1717774105,
+        "narHash": "sha256-HV97wqUQv9wvptiHCb3Y0/YH0lJ60uZ8FYfEOIzYEqI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d226935fd75012939397c83f6c385e4d6d832288",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -740,7 +772,27 @@
         "devenv": "devenv",
         "disko": "disko",
         "nixpkgs": "nixpkgs_4",
+        "sops-nix": "sops-nix",
         "srvos": "srvos"
+      }
+    },
+    "sops-nix": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_5",
+        "nixpkgs-stable": "nixpkgs-stable_3"
+      },
+      "locked": {
+        "lastModified": 1718137936,
+        "narHash": "sha256-psA+1Q5fPaK6yI3vzlLINNtb6EeXj111zQWnZYyJS9c=",
+        "owner": "Mic92",
+        "repo": "sops-nix",
+        "rev": "c279dec105dd53df13a5e57525da97905cc0f0d6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Mic92",
+        "repo": "sops-nix",
+        "type": "github"
       }
     },
     "srvos": {

--- a/flake.lock
+++ b/flake.lock
@@ -656,16 +656,16 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1718229064,
-        "narHash": "sha256-ZFav8A9zPNfjZg/wrxh1uZeMJHELRfRgFP+meq01XYk=",
+        "lastModified": 1718437845,
+        "narHash": "sha256-ZT7Oc1g4I4pHVGGjQFnewFVDRLH5cIZhEzODLz9YXeY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5c2ec3a5c2ee9909904f860dadc19bc12cd9cc44",
+        "rev": "752c634c09ceb50c45e751f8791cb45cb3d46c9e",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-23.11",
+        "ref": "nixos-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Cachix CI Agents";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
     devenv.url = "github:cachix/devenv/latest";
 
     sops-nix = {

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,7 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
     devenv.url = "github:cachix/devenv/latest";
+    sops-nix.url = "github:Mic92/sops-nix";
 
     darwin = {
       url = "github:LnL7/nix-darwin";
@@ -44,7 +45,7 @@
     ];
   };
 
-  outputs = { self, devenv, nixpkgs, cachix-deploy-flake, cachix-flake, srvos, disko, ... }:
+  outputs = { self, devenv, nixpkgs, cachix-deploy-flake, cachix-flake, srvos, disko, sops-nix, ... }:
     let
       linuxMachineName = "linux";
       sshPubKeys = {
@@ -82,6 +83,7 @@
         srvos.nixosModules.server
         srvos.nixosModules.mixins-systemd-boot
         disko.nixosModules.disko
+        sops-nix.nixosModules.sops
         ./agents/linux.nix
         (import ./disko-hetzner-cloud.nix { disks = [ "/dev/sda" ]; })
         {
@@ -107,6 +109,7 @@
         cachix-deploy-lib.nixos {
           imports = [
             bootstrapNixOS.module ./agents/linux.nix
+            sops-nix.nixosModules.sops
           ];
 
           # TODO: This should also be set for bootstrapping
@@ -152,6 +155,7 @@
         default = pkgs.mkShell {
           buildInputs = [
             cachix-deploy-flake.packages.${system}.bootstrapHetzner
+            pkgs.sops
           ];
         };
       });

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,11 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
     devenv.url = "github:cachix/devenv/latest";
-    sops-nix.url = "github:Mic92/sops-nix";
+
+    sops-nix = {
+      url = "github:Mic92/sops-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
 
     darwin = {
       url = "github:LnL7/nix-darwin";

--- a/secrets.yaml
+++ b/secrets.yaml
@@ -1,4 +1,4 @@
-github-runner-token: ENC[AES256_GCM,data:RlPbFcXlc5no1WPRWp8y9gIXx7EyeOQEcE0yGsFfsQteDdZDWIwoxQ7KpKUkArCGUBL1vfAZtM7M8AZ9iq1Z9p53rubbjeAwNC5l6AqfHH6rA/9d2K3DfMLvGYPA,iv:AsnRdyetHMVA4G3hJ7bYsLbJRrBoIJnpD8gNnKYl+38=,tag:SXzaE85e4oK8KdD1EyIAqg==,type:str]
+github-runner-token: ENC[AES256_GCM,data:9cqWD+3RoB7qCTJyIBho+9kI70dZ6Y5EzhywHSZ9pKMhtXQo/FSXusyyxrMreiSNld9Wz5PsR4biHBHkLP540SFP1wiISvjZgF7XznrQrYHd/aP/XNKoPigxHSu3,iv:1aICaG/SyXUMNTnvtueXE433Vknoa/JGBxt+91KgdMg=,tag:zretrNAeWMu7POh0YKd9Nw==,type:str]
 sops:
     kms: []
     gcp_kms: []
@@ -23,8 +23,8 @@ sops:
             S0ZWcklZdkVpSHYyNHpFMW1OL0hjM0UK97cs51HLwNhAimVxtNgA9t/X2vnR2rgX
             1VkBJMIsXuJVlLiTxRRy0k3uVXf//tf4sc3D/HvXKuBwxt3WLl5buw==
             -----END AGE ENCRYPTED FILE-----
-    lastmodified: "2024-06-14T17:13:58Z"
-    mac: ENC[AES256_GCM,data:wZ+BhoKhSPGnIwJg+4N4BecKCpU7gURol9b5drCZeGIbRj8Y/0JxEsqGmHYOW3p82eXedUHTMkL7x3LdBpria2zBayfQkq4iBfqZALq4R/Vp0sEkPgcipOxzjq8QQCQX3WWImLOAyZlFIzUZUkL6mC/xZpJNawI1WNKZ3ZWKA94=,iv:6X90veqakHMSXSLKWXK5BWSTADmJaaFIOsJ9ZoTn8Fk=,tag:Gtc7z7gwWKT/xMiqJrFsLA==,type:str]
+    lastmodified: "2024-06-17T10:16:21Z"
+    mac: ENC[AES256_GCM,data:xiKY3QCQKVWjvSCjmg1cTHBipIuX3SGK3WQduuCMB+yyIZAsRFUYyrSj/O/CyiGyCBkuOIJlfqNR2mccooeX1alcNvg1u4yQn4f8U0HW28VJD+3tzYfrceYa6PEXmAX8KdWoOLBjAQz/n3HHx0w1ocp1c+7dydZ0QxhnHt7cvvM=,iv:XSiqhGJT1oIsiIAKVOfe5Mli3bkSZYdmtdUJwkQxHmA=,tag:eGbCX/tW0zZk/m5+DeEm8w==,type:str]
     pgp: []
     unencrypted_suffix: _unencrypted
     version: 3.8.1

--- a/secrets.yaml
+++ b/secrets.yaml
@@ -5,23 +5,32 @@ sops:
     azure_kv: []
     hc_vault: []
     age:
+        - recipient: age1pwtvmk9hhwgytkumpjxctvzyw9pledgm44qn8xjzq3s8rduy7fjqllp0nz
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBPakRaWjVObG10aGNNajNh
+            VkNEVkE5aERqRlFBamwzNG5BbiswdnI2YXlZClRYNWJuQy9icjdxSGZRK08vblIx
+            RCtoVmw3R3lUREVDUjBPank4SGduV2MKLS0tIE5Ka3dmd1M5em9GYXNURGhlSzBs
+            b09aU0pja0o1aHRRUnRFdGlvTzgwbW8K7dajPYOVhm/0GdXKb3reg9UL4XE3KNIB
+            j84cRu0iaAhDwU7CktPQAQm3pQ0J+L390fDnrGaGW4/8626IRPTFGQ==
+            -----END AGE ENCRYPTED FILE-----
         - recipient: age138vqkmsve6sgesskmxefec22h2r0hukhlqlenq3nlgs9tuq3e9yq0xr4le
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSByVWRiSjhnTmx5OW8xM1pt
-            ODB1ejNRWk1RNElFRzR0UFZMa3phakMxS1c4CnZIOW5UOE05NHlpRUVmb01xR3JY
-            QUJOU05oSGxmdXF5Q1gwWnF1TENqZ2MKLS0tIGp4TnpqajBGdlBadXJ1MFVJb1V0
-            Yk9YS2R5dmlyRncyR3dhYkFSajU4OFEKRJOF0IWrZeqUv5Jy5A0RpoGZLCaIemLW
-            04WX9WaIfmPdhu8Nd1D/azx6FmNlTHQU86fdJ676i/lJ7qBQyOCM9A==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBNZnlKMnk5Y2g4YUs4S2px
+            MWVveVBqa2tDWk1lamFBM1FvRlppNGwwb1JjCkNpNXVaMnQzNlJQTDU5dlU3ZkpB
+            dGpDaHdnQzR4T3VUaFN6cS9JdVZFajgKLS0tIElQZEpjajRMRUg2Wk5uVHBwc05Y
+            ZTVNcXQyTDhRYXJFMHA5aisvTjliSUEKf5znvNl1nbA2BELhMk/Q/ocwdrUqqjsZ
+            HIZrUmNP9HBQT/GOvYGGXE5Kci6PJXVxFtSFedjm0vUSpsfkziVtOw==
             -----END AGE ENCRYPTED FILE-----
         - recipient: age1xs6sg06q2jj93skp6s0advfa666hjxr28c8f5egc2r3fvclwwgzst7uuk0
           enc: |
             -----BEGIN AGE ENCRYPTED FILE-----
-            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDT1hheHdQMTh6eTN1Nkxk
-            L3pKQzVXL0NMVThzaHREZzR5dXNSWWZucEQ0ClkvTkVjSWZ6UDltUzE3YkNiL3pF
-            d1RuNXl4bzJ6aHhjb3JLUU1sV3BwRmsKLS0tIDFkTXpIZjdjK1hXKzBBM3lEOTRJ
-            S0ZWcklZdkVpSHYyNHpFMW1OL0hjM0UK97cs51HLwNhAimVxtNgA9t/X2vnR2rgX
-            1VkBJMIsXuJVlLiTxRRy0k3uVXf//tf4sc3D/HvXKuBwxt3WLl5buw==
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSA5NTNlVEozWFZaclNYSmF2
+            OFRRdmpYZjdXZStYZHFHVkplQm1na2dNS2p3ClB5OXk0dGV5YXpnVS9RNklnUEh3
+            UWZtT0tRNGZCYTRoYjVzWDJ1eFBNM2MKLS0tIDAxOFFmUDFFdllXU0Nwek5NNjhq
+            Mkx5cW1XazMzd245akZRZWx4Z29VZjAKzJCyqOP2pvG0v6aKNwdRUDzbZ26qFvfP
+            ViDFDNnaJPNnsO8nCuXQZx0p/WYn5SW6BgL5mRgKeEkSbknRINsBdg==
             -----END AGE ENCRYPTED FILE-----
     lastmodified: "2024-06-17T10:16:21Z"
     mac: ENC[AES256_GCM,data:xiKY3QCQKVWjvSCjmg1cTHBipIuX3SGK3WQduuCMB+yyIZAsRFUYyrSj/O/CyiGyCBkuOIJlfqNR2mccooeX1alcNvg1u4yQn4f8U0HW28VJD+3tzYfrceYa6PEXmAX8KdWoOLBjAQz/n3HHx0w1ocp1c+7dydZ0QxhnHt7cvvM=,iv:XSiqhGJT1oIsiIAKVOfe5Mli3bkSZYdmtdUJwkQxHmA=,tag:eGbCX/tW0zZk/m5+DeEm8w==,type:str]

--- a/secrets.yaml
+++ b/secrets.yaml
@@ -1,0 +1,30 @@
+github-runner-token: ENC[AES256_GCM,data:RlPbFcXlc5no1WPRWp8y9gIXx7EyeOQEcE0yGsFfsQteDdZDWIwoxQ7KpKUkArCGUBL1vfAZtM7M8AZ9iq1Z9p53rubbjeAwNC5l6AqfHH6rA/9d2K3DfMLvGYPA,iv:AsnRdyetHMVA4G3hJ7bYsLbJRrBoIJnpD8gNnKYl+38=,tag:SXzaE85e4oK8KdD1EyIAqg==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age:
+        - recipient: age138vqkmsve6sgesskmxefec22h2r0hukhlqlenq3nlgs9tuq3e9yq0xr4le
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSByVWRiSjhnTmx5OW8xM1pt
+            ODB1ejNRWk1RNElFRzR0UFZMa3phakMxS1c4CnZIOW5UOE05NHlpRUVmb01xR3JY
+            QUJOU05oSGxmdXF5Q1gwWnF1TENqZ2MKLS0tIGp4TnpqajBGdlBadXJ1MFVJb1V0
+            Yk9YS2R5dmlyRncyR3dhYkFSajU4OFEKRJOF0IWrZeqUv5Jy5A0RpoGZLCaIemLW
+            04WX9WaIfmPdhu8Nd1D/azx6FmNlTHQU86fdJ676i/lJ7qBQyOCM9A==
+            -----END AGE ENCRYPTED FILE-----
+        - recipient: age1xs6sg06q2jj93skp6s0advfa666hjxr28c8f5egc2r3fvclwwgzst7uuk0
+          enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBDT1hheHdQMTh6eTN1Nkxk
+            L3pKQzVXL0NMVThzaHREZzR5dXNSWWZucEQ0ClkvTkVjSWZ6UDltUzE3YkNiL3pF
+            d1RuNXl4bzJ6aHhjb3JLUU1sV3BwRmsKLS0tIDFkTXpIZjdjK1hXKzBBM3lEOTRJ
+            S0ZWcklZdkVpSHYyNHpFMW1OL0hjM0UK97cs51HLwNhAimVxtNgA9t/X2vnR2rgX
+            1VkBJMIsXuJVlLiTxRRy0k3uVXf//tf4sc3D/HvXKuBwxt3WLl5buw==
+            -----END AGE ENCRYPTED FILE-----
+    lastmodified: "2024-06-14T17:13:58Z"
+    mac: ENC[AES256_GCM,data:wZ+BhoKhSPGnIwJg+4N4BecKCpU7gURol9b5drCZeGIbRj8Y/0JxEsqGmHYOW3p82eXedUHTMkL7x3LdBpria2zBayfQkq4iBfqZALq4R/Vp0sEkPgcipOxzjq8QQCQX3WWImLOAyZlFIzUZUkL6mC/xZpJNawI1WNKZ3ZWKA94=,iv:6X90veqakHMSXSLKWXK5BWSTADmJaaFIOsJ9ZoTn8Fk=,tag:Gtc7z7gwWKT/xMiqJrFsLA==,type:str]
+    pgp: []
+    unencrypted_suffix: _unencrypted
+    version: 3.8.1


### PR DESCRIPTION
TODO:

- [x] Add domen's age key. I generated it from my ssh key, but it needs to be ed25519.
- [ ] Consider agenix for macOS support. Otherwise we'd need home-manager for sops on macOS, or upstream to sops-nix.