### PR TITLE
chore(deps): lock file maintenance

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -68,11 +68,11 @@
         "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1717420532,
-        "narHash": "sha256-OCCmI69EMaA4BcxRKrXJsx5Ozua2f/PKEy4aJbE7ziM=",
+        "lastModified": 1719923519,
+        "narHash": "sha256-7Rhljj2fsklFRsu+eq7N683Z9qukmreMEj5C1GqCrSA=",
         "owner": "cachix",
         "repo": "cachix",
-        "rev": "5727f0676f08a4b41ed13d403ec64dcce989f6e5",
+        "rev": "4e9e71f78b9500fa6210cf1eaa4d75bdbab777c3",
         "type": "github"
       },
       "original": {
@@ -88,11 +88,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718440858,
-        "narHash": "sha256-iMVwdob8F6P6Ib+pnhMZqyvYI10ZxmvA885jjnEaO54=",
+        "lastModified": 1721719500,
+        "narHash": "sha256-nnkqjv4Y37Hydjh6HE9wW4kSkV5Q7q4iIXlL5lwUFOw=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "58b905ea87674592aa84c37873e6c07bc3807aba",
+        "rev": "884f3fe6d9bf056ba0017c132c39c1f0d07d4fec",
         "type": "github"
       },
       "original": {
@@ -162,11 +162,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718588625,
-        "narHash": "sha256-8ZbrJq1jcmyzJ4SDkvd8JOZD4/fNUHpL4cpqVe4w3CU=",
+        "lastModified": 1721735625,
+        "narHash": "sha256-4T0FK0b3Q7Dd7oj79M7GhA9+YqKxxGT0iN+h8yqdP7s=",
         "owner": "nix-community",
         "repo": "disko",
-        "rev": "8262659fc990cecdf6a8de74c3de7b6ec58c2276",
+        "rev": "4698b1ef375e9c904037e0b2049aa73d39ac1b2d",
         "type": "github"
       },
       "original": {
@@ -266,24 +266,6 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
-      "inputs": {
-        "systems": "systems_2"
-      },
-      "locked": {
         "lastModified": 1689068808,
         "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
         "owner": "numtide",
@@ -297,9 +279,9 @@
         "type": "github"
       }
     },
-    "flake-utils_3": {
+    "flake-utils_2": {
       "inputs": {
-        "systems": "systems_3"
+        "systems": "systems_2"
       },
       "locked": {
         "lastModified": 1710146030,
@@ -576,11 +558,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1710695816,
-        "narHash": "sha256-3Eh7fhEID17pv9ZxrPwCLfqXnYP006RKzSs0JptsN84=",
+        "lastModified": 1718811006,
+        "narHash": "sha256-0Y8IrGhRmBmT7HHXlxxepg2t8j1X90++qRN3lukGaIk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "614b4613980a522ba49f0d194531beddbb7220d3",
+        "rev": "03d771e513ce90147b65fe922d87d3a0356fc125",
         "type": "github"
       },
       "original": {
@@ -608,16 +590,16 @@
     },
     "nixpkgs-stable_3": {
       "locked": {
-        "lastModified": 1718478900,
-        "narHash": "sha256-v43N1gZLcGkhg3PdcrKUNIZ1L0FBzB2JqhIYEyKAHEs=",
+        "lastModified": 1721524707,
+        "narHash": "sha256-5NctRsoE54N86nWd0psae70YSLfrOek3Kv1e8KoXe/0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c884223af91820615a6146af1ae1fea25c107005",
+        "rev": "556533a23879fc7e5f98dd2e0b31a6911a213171",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "release-23.11",
+        "ref": "release-24.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -656,11 +638,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1718437845,
-        "narHash": "sha256-ZT7Oc1g4I4pHVGGjQFnewFVDRLH5cIZhEzODLz9YXeY=",
+        "lastModified": 1721548954,
+        "narHash": "sha256-7cCC8+Tdq1+3OPyc3+gVo9dzUNkNIQfwSDJ2HSi2u3o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "752c634c09ceb50c45e751f8791cb45cb3d46c9e",
+        "rev": "63d37ccd2d178d54e7fb691d7ec76000740ea24a",
         "type": "github"
       },
       "original": {
@@ -672,7 +654,7 @@
     },
     "poetry2nix": {
       "inputs": {
-        "flake-utils": "flake-utils_2",
+        "flake-utils": "flake-utils",
         "nix-github-actions": "nix-github-actions",
         "nixpkgs": [
           "devenv",
@@ -698,7 +680,6 @@
     "pre-commit-hooks": {
       "inputs": {
         "flake-compat": "flake-compat_2",
-        "flake-utils": "flake-utils",
         "gitignore": "gitignore",
         "nixpkgs": [
           "cachix-flake",
@@ -707,11 +688,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1715609711,
-        "narHash": "sha256-/5u29K0c+4jyQ8x7dUIEUWlz2BoTSZWUP2quPwFCE7M=",
+        "lastModified": 1719259945,
+        "narHash": "sha256-F1h+XIsGKT9TkGO3omxDLEb/9jOOsI6NnzsXFsZhry4=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "c182c876690380f8d3b9557c4609472ebfa1b141",
+        "rev": "0ff4381bbb8f7a52ca4a851660fc7a437a4c6e07",
         "type": "github"
       },
       "original": {
@@ -726,7 +707,7 @@
           "devenv",
           "flake-compat"
         ],
-        "flake-utils": "flake-utils_3",
+        "flake-utils": "flake-utils_2",
         "gitignore": "gitignore_2",
         "nixpkgs": [
           "devenv",
@@ -768,11 +749,11 @@
         "nixpkgs-stable": "nixpkgs-stable_3"
       },
       "locked": {
-        "lastModified": 1718506969,
-        "narHash": "sha256-Pm9I/BMQHbsucdWf6y9G3xBZh3TMlThGo4KBbeoeczg=",
+        "lastModified": 1721688883,
+        "narHash": "sha256-9jsjsRKtJRqNSTXKj9zuDFRf2PGix30nMx9VKyPgD2U=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "797ce4c1f45a85df6dd3d9abdc53f2691bea9251",
+        "rev": "aff2f88277dabe695de4773682842c34a0b7fd54",
         "type": "github"
       },
       "original": {
@@ -788,11 +769,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1718585173,
-        "narHash": "sha256-G5DB6D3p8ucyGfmWt3JmiWcVW55DeuUoiT230wQ9Am4=",
+        "lastModified": 1721612563,
+        "narHash": "sha256-6T6GkLuNVbgDKijcBY/5mUiK8gO2Xi2QFM13hUKa2a0=",
         "owner": "numtide",
         "repo": "srvos",
-        "rev": "c607ffef7c234d88f37ed12d75b2c48de3f4b3fe",
+        "rev": "936858820dcad0e958f16f0e9652519bef045d5d",
         "type": "github"
       },
       "original": {
@@ -817,21 +798,6 @@
       }
     },
     "systems_2": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_3": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'cachix-flake':
    'github:cachix/cachix/5727f0676f08a4b41ed13d403ec64dcce989f6e5?narHash=sha256-OCCmI69EMaA4BcxRKrXJsx5Ozua2f/PKEy4aJbE7ziM%3D' (2024-06-03)
  → 'github:cachix/cachix/4e9e71f78b9500fa6210cf1eaa4d75bdbab777c3?narHash=sha256-7Rhljj2fsklFRsu%2Beq7N683Z9qukmreMEj5C1GqCrSA%3D' (2024-07-02)
• Updated input 'cachix-flake/pre-commit-hooks':
    'github:cachix/pre-commit-hooks.nix/c182c876690380f8d3b9557c4609472ebfa1b141?narHash=sha256-/5u29K0c%2B4jyQ8x7dUIEUWlz2BoTSZWUP2quPwFCE7M%3D' (2024-05-13)
  → 'github:cachix/pre-commit-hooks.nix/0ff4381bbb8f7a52ca4a851660fc7a437a4c6e07?narHash=sha256-F1h%2BXIsGKT9TkGO3omxDLEb/9jOOsI6NnzsXFsZhry4%3D' (2024-06-24)
• Removed input 'cachix-flake/pre-commit-hooks/flake-utils' • Removed input 'cachix-flake/pre-commit-hooks/flake-utils/systems' • Updated input 'cachix-flake/pre-commit-hooks/nixpkgs-stable':
    'github:NixOS/nixpkgs/614b4613980a522ba49f0d194531beddbb7220d3?narHash=sha256-3Eh7fhEID17pv9ZxrPwCLfqXnYP006RKzSs0JptsN84%3D' (2024-03-17)
  → 'github:NixOS/nixpkgs/03d771e513ce90147b65fe922d87d3a0356fc125?narHash=sha256-0Y8IrGhRmBmT7HHXlxxepg2t8j1X90%2B%2BqRN3lukGaIk%3D' (2024-06-19)
• Updated input 'darwin':
    'github:LnL7/nix-darwin/58b905ea87674592aa84c37873e6c07bc3807aba?narHash=sha256-iMVwdob8F6P6Ib%2BpnhMZqyvYI10ZxmvA885jjnEaO54%3D' (2024-06-15)
  → 'github:LnL7/nix-darwin/884f3fe6d9bf056ba0017c132c39c1f0d07d4fec?narHash=sha256-nnkqjv4Y37Hydjh6HE9wW4kSkV5Q7q4iIXlL5lwUFOw%3D' (2024-07-23)
• Updated input 'disko':
    'github:nix-community/disko/8262659fc990cecdf6a8de74c3de7b6ec58c2276?narHash=sha256-8ZbrJq1jcmyzJ4SDkvd8JOZD4/fNUHpL4cpqVe4w3CU%3D' (2024-06-17)
  → 'github:nix-community/disko/4698b1ef375e9c904037e0b2049aa73d39ac1b2d?narHash=sha256-4T0FK0b3Q7Dd7oj79M7GhA9%2BYqKxxGT0iN%2Bh8yqdP7s%3D' (2024-07-23)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/752c634c09ceb50c45e751f8791cb45cb3d46c9e?narHash=sha256-ZT7Oc1g4I4pHVGGjQFnewFVDRLH5cIZhEzODLz9YXeY%3D' (2024-06-15)
  → 'github:NixOS/nixpkgs/63d37ccd2d178d54e7fb691d7ec76000740ea24a?narHash=sha256-7cCC8%2BTdq1%2B3OPyc3%2BgVo9dzUNkNIQfwSDJ2HSi2u3o%3D' (2024-07-21)
• Updated input 'sops-nix':
    'github:Mic92/sops-nix/797ce4c1f45a85df6dd3d9abdc53f2691bea9251?narHash=sha256-Pm9I/BMQHbsucdWf6y9G3xBZh3TMlThGo4KBbeoeczg%3D' (2024-06-16)
  → 'github:Mic92/sops-nix/aff2f88277dabe695de4773682842c34a0b7fd54?narHash=sha256-9jsjsRKtJRqNSTXKj9zuDFRf2PGix30nMx9VKyPgD2U%3D' (2024-07-22)
• Updated input 'sops-nix/nixpkgs-stable':
    'github:NixOS/nixpkgs/c884223af91820615a6146af1ae1fea25c107005?narHash=sha256-v43N1gZLcGkhg3PdcrKUNIZ1L0FBzB2JqhIYEyKAHEs%3D' (2024-06-15)
  → 'github:NixOS/nixpkgs/556533a23879fc7e5f98dd2e0b31a6911a213171?narHash=sha256-5NctRsoE54N86nWd0psae70YSLfrOek3Kv1e8KoXe/0%3D' (2024-07-21)
• Updated input 'srvos':
    'github:numtide/srvos/c607ffef7c234d88f37ed12d75b2c48de3f4b3fe?narHash=sha256-G5DB6D3p8ucyGfmWt3JmiWcVW55DeuUoiT230wQ9Am4%3D' (2024-06-17)
  → 'github:numtide/srvos/936858820dcad0e958f16f0e9652519bef045d5d?narHash=sha256-6T6GkLuNVbgDKijcBY/5mUiK8gO2Xi2QFM13hUKa2a0%3D' (2024-07-22)