### PR TITLE
common: trust our cache's public key

### DIFF
--- a/modules/common.nix
+++ b/modules/common.nix
@@ -3,6 +3,7 @@
 {
   nix.package = pkgs.nixVersions.nix_2_28;
   nix.channel.enable = false;
+
   # Run GC every hour
   nix.gc = {
     automatic = true;
@@ -17,10 +18,16 @@
     # Our macOS install is single-user, so we can't run GC as root.
     user = "hetzner";
   };
+
   # Optimse the store to save disk space.
   # Do not auto-optimise on macOS. Too many issues: https://github.com/NixOS/nix/issues/7273
   nix.optimise.automatic = pkgs.stdenv.isLinux;
   nix.settings.auto-optimise-store = pkgs.stdenv.isLinux;
+
+  nix.settings.trusted-public-keys = [
+    "cachix-ci-agents.cachix.org-1:qVO9icjGen2UY8QnkygVYKajmjwjp3l6cHUT6t+lkHs="
+  ];
+
   nix.extraOptions = ''
     always-allow-substitutes = true
     min-free = ${toString (10 * 1024 * 1024 * 1024)}


### PR DESCRIPTION
Otherwise, the store paths used to build our runner are untrusted.