### PR TITLE
Use networkd and Nix 2.35.2

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -548,17 +548,17 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1785747939,
-        "narHash": "sha256-D740uKsMbgsfK2oaDenJLLPIZfq7W0/g4KN/Fls8eKs=",
+        "lastModified": 1786582076,
+        "narHash": "sha256-E0LFrh+SAL0olCcryIZikGS+8T0pMe0cO7qnHgl2qi0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "104240a772428cc2e20d8fd86c9ddbb886bbaff2",
+        "rev": "9b88fef0ad376b5c08854c771cd28242f1b76df2",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
+        "rev": "9b88fef0ad376b5c08854c771cd28242f1b76df2",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,8 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
-    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    # Nix 2.35.2 until the package bump reaches nixpkgs-unstable.
+    nixpkgs-unstable.url = "github:NixOS/nixpkgs/9b88fef0ad376b5c08854c771cd28242f1b76df2";
     devenv.url = "github:cachix/devenv/latest";
 
     agenix = {

--- a/machines/linux.nix
+++ b/machines/linux.nix
@@ -30,6 +30,10 @@ in
       boot.loader.grub.efiInstallAsRemovable = lib.mkForce false;
       boot.binfmt.emulatedSystems = [ "aarch64-linux" ];
 
+      # Use networkd instead of dhcpcd. The latter monitors Docker's
+      # short-lived veth interfaces and can crash when they disappear.
+      networking.useNetworkd = true;
+
       users.users.root.openssh.authorizedKeys.keys = builtins.attrValues sshKeys.admins;
     }
   ];


### PR DESCRIPTION
## What changed

- switch the AMD Linux deployment from `dhcpcd` to `systemd-networkd`
- pin `nixpkgs-unstable` to the Nix 2.35.2 package bump

## Why

`dhcpcd` 10.3.1 is crashing in `ipv6nd_expire` while tracking Docker short-lived veth interfaces. NixOS default networkd DHCP unit excludes virtual links, avoiding that failure mode.

The Nix pin upgrades the deployed `nix-ci` package from 2.35.1 to 2.35.2 while the package bump is still pending in `nixpkgs-unstable`.

## Validation

- rebased onto current `origin/main`
- `git diff --check`
- evaluated `packages.x86_64-linux.nix-ci.version` as `2.35.2`
- evaluated the AMD deployment with `networking.useNetworkd = true`, `dhcpcd` disabled, and `systemd-resolved` enabled

The full x86_64 Linux closure build is intentionally left to CI.